### PR TITLE
jaal-dijkstra-student.json: initialState and clicks

### DIFF
--- a/spec/test/valid/jaal-dijkstra-student.json
+++ b/spec/test/valid/jaal-dijkstra-student.json
@@ -112,7 +112,7 @@
             {
               "id": "nodeB",
               "key": "B", 
-              "style": "visited"
+              "style": "unvisited"
             },
             {
               "id": "nodeC",
@@ -127,7 +127,7 @@
             {
               "id": "nodeE",
               "key": "E", 
-              "style": "visited"
+              "style": "unvisited"
             },
             {
               "id": "nodeF",
@@ -147,7 +147,7 @@
             {
               "id": "nodeI",
               "key": "I", 
-              "style": "visited"
+              "style": "unvisited"
             },
             {
               "id": "nodeJ",
@@ -172,7 +172,7 @@
             {
               "id": "nodeN",
               "key": "N", 
-              "style": "visited"
+              "style": "unvisited"
             },
             {
               "id": "nodeO",
@@ -185,13 +185,13 @@
               "id": "edge0",
               "node": [ "nodeA", "nodeB" ],
               "tag": "5", 
-              "style": "selected"
+              "style": "unselected"
             },
             {
               "id": "edge1", 
               "node": ["nodeA", "nodeE"], 
               "tag": "5", 
-              "style": "selected"
+              "style": "unselected"
             },
             {
               "id": "edge2", 
@@ -257,7 +257,7 @@
               "id": "edge12", 
               "node": ["nodeI", "nodeN"], 
               "tag": "7", 
-              "style": "selected"
+              "style": "unselected"
             },
             {
               "id": "edge13", 


### PR DESCRIPTION
Fulfill #4 ,  #5 , and #7 . 

jaal-dijkstra-student.json is a copy of jaal-dijkstra.json. The initialState is set to an undirected, weighted graph as per /spec/test/valid/figures/dijkstra-solution/initial.png. 
The animation is set as 3 click events for edges AB, AE, IN as per /spec/test/valid/figures/dijkstra-solution/student*.png. 

The nodes and edges are set with the styles visited/unvisited (nodes) or selected/unselected (edges) as in /spec/test/valid/figures/dijkstra-solution/student03.png . 

Add modelAnswer array of clicks as per /spec/test/valid/figures/dijkstra-solution/model*.png. 
Correct values in score as per the steps as above. 