### PR TITLE
test.js: Invalid schema error message validation

### DIFF
--- a/spec/test.js
+++ b/spec/test.js
@@ -100,9 +100,27 @@ const validate_schema = (schema, test_file, validity, dependencies = []) => {
             console.log(validate.errors); 
             tests_failed++;   
         } else {
+            /**
+             * Make sure that the correct error is produced. 
+             * The expected error is stored in the errorInstancePath
+             * and errorMessage field of the test files. 
+             */
+            
             console.log("Test " + file +  ":");
-            console.log(validate.errors);
-            tests_passed++;
+            console.log("\t", validate.errors[0].instancePath, 
+                              validate.errors[0].message);
+            const instancePath = validate.errors[0].instancePath;
+            const message = validate.errors[0].message;
+                        
+            if (test_case.errorInstancePath === instancePath && 
+                test_case.errorMessage === message) {
+                tests_passed++;
+            } else {
+                console.log(validate.errors);
+                console.log("Expected error: ", test_case.errorInstancePath, 
+                            test_case.errorMessage);
+                tests_failed++;
+            }
         }
         
     }

--- a/spec/test.js
+++ b/spec/test.js
@@ -105,7 +105,7 @@ const validate_schema = (schema, test_file, validity, dependencies = []) => {
              * The expected error is stored in the errorInstancePath
              * and errorMessage field of the test files. 
              */
-            
+
             console.log("Test " + file +  ":");
             console.log("\t", validate.errors[0].instancePath, 
                               validate.errors[0].message);
@@ -116,7 +116,6 @@ const validate_schema = (schema, test_file, validity, dependencies = []) => {
                 test_case.errorMessage === message) {
                 tests_passed++;
             } else {
-                console.log(validate.errors);
                 console.log("Expected error: ", test_case.errorInstancePath, 
                             test_case.errorMessage);
                 tests_failed++;

--- a/spec/test/invalid/edge-1node.json
+++ b/spec/test/invalid/edge-1node.json
@@ -1,5 +1,7 @@
 {
   "description": "An Edge cannot have only one node.",
   "id": "edge1",
-  "node": [ "node1" ]
+  "node": [ "node1" ], 
+  "errorInstancePath": "/node", 
+  "errorMessage": "must NOT have fewer than 2 items"
 }

--- a/spec/test/invalid/edge-3nodes.json
+++ b/spec/test/invalid/edge-3nodes.json
@@ -1,5 +1,7 @@
 {
   "description": "An Edge cannot have three nodes.",  
   "id": "edge1",
-  "node": [ "node1", "node2", "node3" ]
+  "node": [ "node1", "node2", "node3" ], 
+  "errorInstancePath": "/node", 
+  "errorMessage": "must NOT have more than 2 items"
 }

--- a/spec/test/invalid/event-click-invalid-id.json
+++ b/spec/test/invalid/event-click-invalid-id.json
@@ -2,5 +2,7 @@
   "description": "An Event whose object reference has an invalid id value.",
   "type": "click",
   "time": 1500,
-  "object": "multiedge1"
+  "object": "multiedge1", 
+  "errorInstancePath": "/object", 
+  "errorMessage": "must match pattern \"^edge|graph|keyvalue|matrix|node\""
 }

--- a/spec/test/invalid/event-click-invalid-type.json
+++ b/spec/test/invalid/event-click-invalid-type.json
@@ -2,5 +2,7 @@
   "description": "An Event which has an invalid type.",
   "type": "an unknown event",
   "time": 1500,
-  "object": "edge1"
+  "object": "edge1", 
+  "errorInstancePath": "/type", 
+  "errorMessage": "must match pattern \"^click|grade|undo|operation|narration$\""
 }

--- a/spec/test/invalid/event-click-no-object.json
+++ b/spec/test/invalid/event-click-no-object.json
@@ -1,5 +1,7 @@
 {
   "description": "An Event which has no type.",
   "type": "click",
-  "time": 1500
+  "time": 1500, 
+  "errorInstancePath": "", 
+  "errorMessage": "must have required property 'object'"
 }

--- a/spec/test/invalid/event-time-is-negative.json
+++ b/spec/test/invalid/event-time-is-negative.json
@@ -2,5 +2,7 @@
   "description": "Events cannot have negative time value.",
   "type": "click",
   "time": -2,
-  "object": "edge1"
+  "object": "edge1", 
+  "errorInstancePath": "/time", 
+  "errorMessage": "must be >= 0"
 }

--- a/spec/test/invalid/event-time-is-string.json
+++ b/spec/test/invalid/event-time-is-string.json
@@ -2,5 +2,7 @@
   "description": "Events cannot have a time which is a string.",
   "type": "click",
   "time": "2021-10-05T12:57:22.831Z",
-  "object": "edge1"
+  "object": "edge1", 
+  "errorInstancePath": "/time", 
+  "errorMessage": "must be integer"
 }

--- a/spec/test/invalid/jaal-empty.json
+++ b/spec/test/invalid/jaal-empty.json
@@ -1,3 +1,5 @@
 {
-  "description": "JAAL data cannot be empty."
+  "description": "JAAL data cannot be empty.", 
+  "errorInstancePath": "", 
+  "errorMessage": "must have required property 'metadata'"
 }

--- a/spec/test/invalid/jaal-metadata_only.json
+++ b/spec/test/invalid/jaal-metadata_only.json
@@ -1,4 +1,6 @@
 {
   "description": "A JAAL recording with only Metadata present is invalid.",
-  "metadata": {}
+  "metadata": {}, 
+  "errorInstancePath": "", 
+  "errorMessage": "must have required property 'definitions'"
 }

--- a/spec/test/invalid/jaal-toplevel-empty.json
+++ b/spec/test/invalid/jaal-toplevel-empty.json
@@ -3,5 +3,7 @@
   "metadata": {},
   "definitions": {},
   "initialState": {},
-  "animation": {}
+  "animation": {}, 
+  "errorInstancePath": "/metadata", 
+  "errorMessage": "must have required property 'jaalVersion'"
 }

--- a/spec/test/invalid/matrix-no-nested-list.json
+++ b/spec/test/invalid/matrix-no-nested-list.json
@@ -7,5 +7,7 @@
     { "id": "node1", "key": "A" },
     { "id": "node2", "key": "B" },
     { "id": "node3", "key": "C" }
-  ]
+  ], 
+  "errorInstancePath": "/key/0", 
+  "errorMessage": "must be array"
 }

--- a/spec/test/invalid/metadata-invalid-simulationStart.json
+++ b/spec/test/invalid/metadata-invalid-simulationStart.json
@@ -8,5 +8,7 @@
     "collection": "JAAL schema testdata",
     "runningLocation": ""
   },
-  "simulationStart": "5.10.2021 12:57"
+  "simulationStart": "5.10.2021 12:57", 
+  "errorInstancePath": "/simulationStart",
+  "errorMessage": "must match pattern \"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z\""
 }

--- a/spec/test/invalid/style-invalid-color1.json
+++ b/spec/test/invalid/style-invalid-color1.json
@@ -1,5 +1,7 @@
 {
   "description": "A Style where the text-color is too short a string.",
   "name": "testStyle",
-  "text-color": "#a0b34"
+  "text-color": "#a0b34", 
+  "errorInstancePath": "/text-color", 
+  "errorMessage": "must match pattern \"^#([0-9]|[a-f]){6}$\""
 }

--- a/spec/test/invalid/style-invalid-color2.json
+++ b/spec/test/invalid/style-invalid-color2.json
@@ -1,5 +1,7 @@
 {
   "comment": "A Style where the text-color is too long a string.",
   "name": "testStyle",
-  "text-color": "#a0b3451"
+  "text-color": "#a0b3451", 
+  "errorInstancePath": "/text-color", 
+  "errorMessage": "must match pattern \"^#([0-9]|[a-f]){6}$\""
 }

--- a/spec/test/invalid/style-invalid-color3.json
+++ b/spec/test/invalid/style-invalid-color3.json
@@ -1,5 +1,7 @@
 {
   "comment": "A Style where the text-color lacks the # character",
   "name": "testStyle",
-  "text-color": "a0b3451"
+  "text-color": "a0b3451", 
+  "errorInstancePath": "/text-color", 
+  "errorMessage": "must match pattern \"^#([0-9]|[a-f]){6}$\""
 }


### PR DESCRIPTION
Fulfill  #15 
Expand invalid tests with a verification of expected failure.
Invalid tests have two new fields: errorInstancePath and errorMessage. These contain the expected error instance path and message. test.js checks the validation errors against these fields for the invalid test cases.

Error messages for failed test shortened with redundant information removed. 