### PR TITLE
Schemas and test data for SVG

### DIFF
--- a/spec/schemas/event.json
+++ b/spec/schemas/event.json
@@ -19,6 +19,10 @@
       "description": "Reference to a JAAL data structure or the Undo button.",
       "type": "string",
       "pattern": "^edge|graph|keyvalue|matrix|node"
+    }, 
+    "image" : {
+      "description": "A string containing an SVG representation of the image",
+      "type": "string"
     }
   },
   "if": {

--- a/spec/test/valid/event-image.json
+++ b/spec/test/valid/event-image.json
@@ -1,0 +1,8 @@
+{
+    "description": "An event where an image is passed along",
+    "type": "click",
+    "time": 1500,
+    "object": "edge1",
+    "image": "<svg height=\"400\" version=\"1.1\" width=\"500\" xmlns=\"http://www.w3.org/2000/svg\" style=\"overflow: hidden;\"><rect fill=\"#e2eedd\" height=\"400\" width=\"500\" x=\"0\" y=\"0\"/><g transform=\"translate(30,30)\"><path stroke=\"#d59f0d\" stroke-width=\"10px\" d=\"M276,243L270,292\"></path><path stroke=\"#d59f0d\" stroke-width=\"10px\" d=\"M302,219L381,218\"></path><path stroke=\"#d59f0d\" stroke-width=\"10px\" d=\"M385,231L286,301\"></path><text x=\"268.5\" y=\"271\">6</text><text x=\"332.5\" y=\"222\">11</text><text x=\"326.5\" y=\"269.5\">16</text><g transform=\"translate(278,219)\"><circle r=\"23\" stroke=\"#002f6c\" stroke-width=\"1px\" fill=\"#ffffff\"></circle><text y=\"5\" text-anchor=\"middle\">K</text></g><g transform=\"translate(403,216)\"><circle r=\"23\" stroke=\"#002f6c\" stroke-width=\"1px\" fill=\"#ffffff\"></circle><text y=\"5\" text-anchor=\"middle\">P</text></g><g transform=\"translate(266,314)\"><circle r=\"23\" stroke=\"#002f6c\" stroke-width=\"1px\" fill=\"#ffffff\"></circle><text y=\"5\" text-anchor=\"middle\">L</text></g></g></svg>"
+  }
+  


### PR DESCRIPTION
Fulfil #24

`spec/schemas/event.json`: add new property `image` which is of the type string.
`spec/test/valid/event-image.json`: An event which has attached SVG string.

Tests pass validation.