### PR TITLE
Forbid multigraph

### DIFF
--- a/doc/jaal-schema-documentation.md
+++ b/doc/jaal-schema-documentation.md
@@ -109,6 +109,8 @@ A graph data structure for representing lists, trees, and graphs.
 The graph is the most generic structure. Trees are graphs without loops.
 Lists are linear trees: each node has at most one children.
 
+Multigraphs are possible in JAAL 1.1, but not intended behaviour. Hypergraphs are explicitly forbidden as an edge must have exactly two nodes it is connected to. 
+
 Some applications:
 - lists (linked list)
 - trees

--- a/spec/schemas/graph.json
+++ b/spec/schemas/graph.json
@@ -22,7 +22,8 @@
       "type": "array",
       "items": {
         "$ref": "edge.json"
-      }
+      },
+      "uniqueItems": true
     },
     "directed": {
       "description": "Directedness of the graph.",

--- a/spec/test.js
+++ b/spec/test.js
@@ -97,7 +97,7 @@ const validate_schema = (schema, test_file, validity, dependencies = []) => {
         }
     } else {
         if (validity === "valid") { // Expect invalid, validation passed
-            console.log("Test", file, "should not fail validation!.");
+            console.log("Test", test_file, "should not fail validation!.");
             console.log(validate.errors);
             tests_failed++;
         } else {                    // Expect invalid, validation failed

--- a/spec/test/invalid/graph-multigraph.json
+++ b/spec/test/invalid/graph-multigraph.json
@@ -1,0 +1,26 @@
+{
+    "description": "An undirected, weighted graph.",
+    "id": "graph1",
+    "node": [
+      { "id": "nodeA", "key": "A" },
+      { "id": "nodeB", "key": "B" }
+    ],
+    "edge": [
+      {
+        "id": "edgeAB",
+        "node": [ "nodeA", "nodeB" ],
+        "tag": "2"
+      },
+      {
+        "id": "edgeAB",
+        "node": [ "nodeA", "nodeB" ],
+        "tag": "2"
+      }
+    ],
+    "directed": true,
+    "dsClass": "graph",
+    "dsSubClass": "weighted",
+    "errorInstancePath": "/edge", 
+    "errorMessage": "must NOT have duplicate items (items ## 0 and 1 are identical)"
+}
+  

--- a/spec/test/valid/graph-directed.json
+++ b/spec/test/valid/graph-directed.json
@@ -1,0 +1,23 @@
+{
+  "description": "An undirected, weighted graph.",
+  "id": "graph1",
+  "node": [
+    { "id": "nodeA", "key": "A" },
+    { "id": "nodeB", "key": "B" }
+  ],
+  "edge": [
+    {
+      "id": "edgeAB",
+      "node": [ "nodeA", "nodeB" ],
+      "tag": "2"
+    },
+    {
+      "id": "edgeBA",
+      "node": [ "nodeB", "nodeA" ],
+      "tag": "2"
+    }
+  ],
+  "directed": true,
+  "dsClass": "graph",
+  "dsSubClass": "weighted"
+}

--- a/spec/test/valid/graph-undirected-weighted.json
+++ b/spec/test/valid/graph-undirected-weighted.json
@@ -75,11 +75,6 @@
       "tag": "9"
     },
     {
-      "id": "edgeHL",
-      "node": [ "nodeH", "nodeL" ],
-      "tag": "9"
-    },
-    {
       "id": "edgeIM",
       "node": [ "nodeI", "nodeM" ],
       "tag": "7"


### PR DESCRIPTION
Fulfil #19 .

`jaal-schema-documentation.md`: add documentation to explain multigraph and hypergraphs are forbidden.
`graph.json`: add uniqueItems constraint to edge array
`test.js`: fix a renamed variable bug
`invalid/graph-multigraph.json`: A graph with a duplicate egde
`valid/graph-directed.json`: A graph with edges AB and BA.
`valid/graph-undirected-weighted.json`: Remove duplicate edge.