### PR TITLE
JAAL 2.0: Accept nested events in the model answer

### DIFF
--- a/doc/jaal-schema-documentation.md
+++ b/doc/jaal-schema-documentation.md
@@ -58,6 +58,7 @@ Properties:
   - UndoCount increases every time the student clicks the Undo button.
     It is handled by the JAAL recorder.
 
+- modelAnswer: the model solution of the exercise. This is stored as either an array of events, or as an array of array of events. In the 2-D array of events case, the intended behaviour is that one step is a major step that matches what the student should be doing, with optional extra minor narration steps. 
 
 ## edge.json
 

--- a/spec/schemas/definitions.json
+++ b/spec/schemas/definitions.json
@@ -38,10 +38,24 @@
     },
     "modelAnswer": {
       "description": "Steps of the model answer.",
-      "type": "array",
-      "items": {
-        "$ref": "event.json"
-      }
+      "oneOf": [
+        {
+          "type": "array", 
+          "items": {
+            "$ref": "event.json"
+          }
+        },
+        {
+          "type": "array", 
+          "items": {
+            "type": "array", 
+            "items": {
+              "$ref": "event.json"
+            }
+          }
+        }
+      ]
+      
     }
   },
   "required": ["score", "modelAnswer"]

--- a/spec/test/valid/definitions-nested-modelAnswer.json
+++ b/spec/test/valid/definitions-nested-modelAnswer.json
@@ -1,0 +1,34 @@
+{
+    "description": "A minimal Definitions data.",
+    "styles": [
+      {
+        "name": "testStyle",
+        "text-color": "#a0b12c"
+      }
+    ],
+    "score": {
+      "modelSteps": 11,
+      "studentSteps": 15,
+      "correctSteps": 5,
+      "undoSteps": 2
+    },
+    "modelAnswer": [
+      [{
+        "type": "operation",
+        "time": 0
+      },
+      {
+        "type": "narration",
+        "time": 1
+      }],
+      [{
+        "type": "operation",
+        "time": 2
+      },
+      {
+        "type": "narration",
+        "time": 3
+      }]
+    ]
+  }
+  


### PR DESCRIPTION
Fulfil #30 . 

`schemas/definitions.json`: modelAnswer accepts either an array of events,
or an array of arrays of events.
`test/valid/definitions-nested-modelAnswer.json`: a test case for nested
events for the modelAnswer.
`jaal-schema-documentation.md`: Add modelAnswer documentation and
describe the new behaviour

All tests are passing.