### PR TITLE
`gradable` property in Event schema

### DIFF
--- a/doc/jaal-schema-documentation.md
+++ b/doc/jaal-schema-documentation.md
@@ -102,6 +102,10 @@ Properties:
   - `operation` is a data structure operation. This is used at least in the
      model answer.
   - `narration` means that the narrative text in the model answer changes.
+- time: the time in milliseconds since the start of the simulation. Must be an integer.
+- object: the name of a JAAL data structure that is referenced with the current event. Must start with `edge`, `graph`, `keyvalue`, `matrix`, or `node`. 
+- gradable: a boolean to indicate whether the current event responds to a gradable step. 
+- image: a string representation of an SVG image. 
 
 ## graph.json
 

--- a/spec/schemas/event.json
+++ b/spec/schemas/event.json
@@ -20,6 +20,10 @@
       "type": "string",
       "pattern": "^edge|graph|keyvalue|matrix|node"
     }, 
+    "gradable": {
+      "description": "Boolean value to indicate whether the current event is considered a gradable step.",
+      "type": "boolean"
+    },
     "image" : {
       "description": "A string containing an SVG representation of the image",
       "type": "string"

--- a/spec/test/valid/event-click.json
+++ b/spec/test/valid/event-click.json
@@ -2,5 +2,6 @@
   "description": "An Event where Edge edge1 is clicked at time 1.5 seconds.",
   "type": "click",
   "time": 1500,
-  "object": "edge1"
+  "object": "edge1",
+  "gradable": true
 }

--- a/spec/test/valid/event-undo.json
+++ b/spec/test/valid/event-undo.json
@@ -1,5 +1,6 @@
 {
   "description": "An Event where the previous event was undoed after 1.5 seconds.",
   "type": "undo",
-  "time": 1500
+  "time": 1500,
+  "gradable": false
 }


### PR DESCRIPTION
Fulfil #32 .

`event.json`: add gradable property which is a boolean.
`event-click.json`: add `gradable: true` to the test case.
`event-undo.json`: add `gradable: false` to the test case.
`jaal-schema-documentation`: Add `time`, `object`, `gradable`, `image`
properties to the documentation with explanation.